### PR TITLE
Fixed invalid repo error on backup server

### DIFF
--- a/roles/backup/tasks/install/borg.yml
+++ b/roles/backup/tasks/install/borg.yml
@@ -7,7 +7,7 @@
 
 - name: Add backports repo
   apt_repository:
-    repo: http://deb.debian.org/debian {{ backports_repo }} main contrib non-free
+    repo: deb http://deb.debian.org/debian {{ backports_repo }} main contrib non-free
     state: present
     update_cache: true
   when: not backports_exists.rc == 0


### PR DESCRIPTION
Fixed error stating 'repo is invalid' by adding 'deb' before the repo URL in the borg.yml file